### PR TITLE
Add tier reset options for admins

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,16 @@
+/* eslint-env node */
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '../types/supabase';
 
-const supabaseUrl = 'https://gbbextghmfnoppbolnwm.supabase.co';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdiYmV4dGdobWZub3BwYm9sbndtIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0ODYwNTY1NiwiZXhwIjoyMDY0MTgxNjU2fQ.fsLigtfN70BdQ2RU_mhmi1ooqAS88WtfvubIaztBQrM';
+declare const process: {
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL?: string;
+    NEXT_PUBLIC_SUPABASE_ANON_KEY?: string;
+  };
+};
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase configuration');


### PR DESCRIPTION
## Summary
- Read Supabase URL and anon key from environment variables
- Support player, kit, and global tier resets with affected counts
- Add dropdown UI and confirmation handling in admin panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 14 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0b12f8b8832384d9f5be536cca38