### PR TITLE
Configure Supabase via Vite environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL="https://your-project.supabase.co"
+VITE_SUPABASE_ANON_KEY="your-anon-key"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 ACD
+
+## Environment Variables
+
+Create a `.env` file based on `.env.example` and supply your Supabase project credentials:
+
+```
+VITE_SUPABASE_URL="https://your-project.supabase.co"
+VITE_SUPABASE_ANON_KEY="your-anon-key"
+```

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,16 +1,8 @@
-/* eslint-env node */
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '../types/supabase';
 
-declare const process: {
-  env: {
-    NEXT_PUBLIC_SUPABASE_URL?: string;
-    NEXT_PUBLIC_SUPABASE_ANON_KEY?: string;
-  };
-};
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase configuration');

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_ANON_KEY: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- Access Supabase using Vite's `import.meta.env` instead of `process.env`
- Declare typed Vite env vars and add example `.env`
- Document required Supabase env vars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1a46139883239aca49a3a1d98796