### PR TITLE
refactor: use Vite env vars for Supabase

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,20 +1,8 @@
-/* eslint-env node */
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '../types/supabase';
 
-declare const process: {
-  env: {
-    NEXT_PUBLIC_SUPABASE_URL?: string;
-    NEXT_PUBLIC_SUPABASE_ANON_KEY?: string;
-  };
-};
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase configuration');


### PR DESCRIPTION
## Summary
- remove process.env Supabase env vars
- use `import.meta.env` for Vite compatibility

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac35b635e8832380f87a2b646aee93