### PR TITLE
Remove duplicate icon import in AdminPanel

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -3,11 +3,9 @@ import { useAuthStore } from '../store/authStore';
 import { usePlayerStore } from '../store/playerStore';
 import { useThemeStore } from '../store/themeStore';
 import { insertInitialPlayers } from '../utils/playerMigration';
-
+ 
 import { AlertCircle, Check, Crown, Trash2, Target, Globe, AlertTriangle, Plus, Save } from 'lucide-react';
-
-import { AlertCircle, Check, Crown, Trash2, Target, Globe, AlertTriangle } from 'lucide-react';
-
+ 
 import { KITS } from '../config/kits';
 import { KitId } from '../types';
 import ResetConfirmModal from './ResetConfirmModal';


### PR DESCRIPTION
## Summary
- remove redundant lucide-react import in AdminPanel

## Testing
- `npm run build` *(fails: supabaseUrl and supabaseAnonKey already declared)*

------
https://chatgpt.com/codex/tasks/task_e_68ac35b727448323829b402925b2f8a3